### PR TITLE
Updated Guzzle to secure version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.5.0",
         "adamwathan/eloquent-oauth": "dev-master",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As per: https://httpoxy.org/

https://github.com/guzzle/guzzle/releases/tag/6.2.1
