### PR TITLE
Make it easier to use custom providers

### DIFF
--- a/src/EloquentOAuthServiceProvider.php
+++ b/src/EloquentOAuthServiceProvider.php
@@ -93,12 +93,10 @@ class EloquentOAuthServiceProvider extends ServiceProvider {
             if (isset($this->getProviderLookup()[$alias])) {
                 $providerClass = $this->getProviderLookup()[$alias];
 
-                if (is_string($providerClass)) {
-                    $provider = new $providerClass($config, new HttpClient, $request);
+                if ($this->app->bound($providerClass)) {
+                    $provider = $this->app->make($providerClass);
                 } else {
-                    // Assume an instantiated provider was supplied, useful
-                    // for custom provider registration.
-                    $provider = $providerClass;
+                    $provider = new $providerClass($config, new HttpClient, $request);
                 }
 
                 $socialnorm->registerProvider($alias, $provider);

--- a/src/EloquentOAuthServiceProvider.php
+++ b/src/EloquentOAuthServiceProvider.php
@@ -90,12 +90,25 @@ class EloquentOAuthServiceProvider extends ServiceProvider {
         }
 
         foreach ($providerAliases as $alias => $config) {
-            if (isset($this->providerLookup[$alias])) {
-                $providerClass = $this->providerLookup[$alias];
-                $provider = new $providerClass($config, new HttpClient, $request);
+            if (isset($this->getProviderLookup()[$alias])) {
+                $providerClass = $this->getProviderLookup()[$alias];
+
+                if (is_string($providerClass)) {
+                    $provider = new $providerClass($config, new HttpClient, $request);
+                } else {
+                    // Assume an instantiated provider was supplied, useful
+                    // for custom provider registration.
+                    $provider = $providerClass;
+                }
+
                 $socialnorm->registerProvider($alias, $provider);
             }
         }
+    }
+
+    protected function getProviderLookup()
+    {
+        return $this->providerLookup;
     }
 
     protected function configureOAuthIdentitiesTable()


### PR DESCRIPTION
Custom providers can now be specified in the config file like any other provider:

``` php
// config/eloquent-oauth.php
return [
    'model' => User::class,
    'table' => 'oauth_identities',
    'providers' => [
        'facebook' => [ /* ... */],
        'google' => [ /* ... */],
        'gumroad' => [
            'client_id' => env('GUMROAD_CLIENT_ID'),
            'client_secret' => env('GUMROAD_CLIENT_SECRET'),
            'redirect_uri' => env('GUMROAD_REDIRECT_URI'),
            'scope' => ['view_sales'],
        ],
    ],
];
```

Specify which class should be used by extending `EloquentOAuthServiceProvider` with your own implementation that maps the provider name to a provider class:

``` php
class MySocialAuthServiceProvider extends EloquentOAuthServiceProvider
{
    protected function getProviderLookup()
    {
        return array_merge($this->providerLookup, [
            'gumroad' => GumroadProvider::class
        ]);
    }
}
```

The `getProviderLookup` method is new and makes it easier to merge your custom providers with any provided by the package.

The package also now looks for a container binding matching the class name you provide, so if your provider can't be constructed using the normal `__construct($config, $httpClient, $request)` signature, you can bind it to the container yourself however you like, and the package will fetch it from the container instead. Of course, if your provider does follow the standard signature, you don't need to worry about binding anything.

Make sure you use your extension of the provider in `config/app.php` instead of the one supplied by the package:

``` php
// config/app.php
return [
    // ...
    'providers' => [
        // ...
        MySocialAuthServiceProvider::class,
        // ...
    ],
    // ...
];
```
