### PR TITLE
Updated readme to reflect changes to /config/app.php

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Add the service provider to the `providers` array in `config/app.php`:
 ```php
 'providers' => [
     // ...
-    'AdamWathan\EloquentOAuthL5\EloquentOAuthServiceProvider',
+    'AdamWathan\EloquentOAuthL5\EloquentOAuthServiceProvider::class',
     // ...
 ]
 ```
@@ -66,7 +66,7 @@ Add the facade to the `aliases` array in `config/app.php`:
 ```php
 'aliases' => [
     // ...
-    'SocialAuth' => 'AdamWathan\EloquentOAuth\Facades\OAuth',
+    'SocialAuth' => 'AdamWathan\EloquentOAuth\Facades\OAuth::class',
     // ...
 ]
 ```

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Add the service provider to the `providers` array in `config/app.php`:
 ```php
 'providers' => [
     // ...
-    'AdamWathan\EloquentOAuthL5\EloquentOAuthServiceProvider::class',
+    AdamWathan\EloquentOAuthL5\EloquentOAuthServiceProvider::class,
     // ...
 ]
 ```
@@ -66,7 +66,7 @@ Add the facade to the `aliases` array in `config/app.php`:
 ```php
 'aliases' => [
     // ...
-    'SocialAuth' => 'AdamWathan\EloquentOAuth\Facades\OAuth::class',
+    'SocialAuth' => AdamWathan\EloquentOAuth\Facades\OAuth::class,
     // ...
 ]
 ```


### PR DESCRIPTION
In laravel 5.3, the providers and aliases sections of /config/app.php no longer use single quotes around the paths and include the `::class` call. This pull request adjusts the readme instructions so that they will copy/paste into the /config/app.php without extra research and modification. 